### PR TITLE
Fix application icons generation

### DIFF
--- a/qubesappmenus/__init__.py
+++ b/qubesappmenus/__init__.py
@@ -47,7 +47,7 @@ class AppmenusSubdirs:
     template_templates_subdir = 'apps-template.templates'
     whitelist = 'whitelisted-appmenus.list'
 
-    
+
 class AppmenusPaths:
     appmenu_start_hvm_template = \
         '/usr/share/qubes-appmenus/qubes-start.desktop'
@@ -296,7 +296,7 @@ class Appmenus(object):
 
         if whitelist:
             expected_icons = \
-                map(lambda x: os.path.splitext(x)[0] + '.png', whitelist)
+                list(map(lambda x: os.path.splitext(x)[0] + '.png', whitelist))
         else:
             expected_icons = os.listdir(srcdir)
 

--- a/qubesappmenus/receive.py
+++ b/qubesappmenus/receive.py
@@ -290,9 +290,10 @@ def process_appmenus_templates(appmenusext, vm, appmenus):
 
 
     for appmenu_name in appmenus.keys():
-        if os.path.exists(
-                os.path.join(appmenusext.templates_dir(vm),
-                    appmenu_name)):
+        appmenu_path = os.path.join(
+            appmenusext.templates_dir(vm),
+            appmenu_name) + '.desktop'
+        if os.path.exists(appmenu_path):
             vm.log.info("Updating {0}".format(appmenu_name))
         else:
             vm.log.info("Creating {0}".format(appmenu_name))
@@ -303,7 +304,7 @@ def process_appmenus_templates(appmenusext, vm, appmenus):
         if 'Icon' in appmenus[appmenu_name]:
             # the following line is used for time comparison
             icondest = os.path.join(appmenusext.template_icons_dir(vm),
-                                    os.path.splitext(appmenu_name)[0] + '.png')
+                                    appmenu_name + '.png')
 
             try:
                 icon = qubesimgconverter.Image. \
@@ -323,8 +324,7 @@ def process_appmenus_templates(appmenusext, vm, appmenus):
                 else:
                     del appmenus[appmenu_name]['Icon']
 
-        create_template(os.path.join(appmenusext.templates_dir(vm),
-            appmenu_name + '.desktop'), appmenu_name,
+        create_template(appmenu_path, appmenu_name,
             appmenus[appmenu_name], legacy_appmenus)
 
     # Delete appmenus of removed applications


### PR DESCRIPTION
The main fix is forcing map object to list, for 'in' operator to work.
But while at it, simplify file names handling a little.

Fixes QubesOS/qubes-issues#2895