### PR TITLE
appmenus: fix compatibility with Qubes OS 4.0

### DIFF
--- a/appmenus-files/qubes-start.desktop
+++ b/appmenus-files/qubes-start.desktop
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Version=1.0
 Type=Application
-Exec=qvm-start --quiet --tray %VMNAME%
+Exec=qvm-start --quiet %VMNAME%
 Icon=%XDGICON%
 Terminal=false
 Name=%VMNAME%: Start


### PR DESCRIPTION
The qvm-start command in Qubes OS 4.0 doesn't have the --tray argument
anymore.