### PR TITLE
Regen appmenus on relevant feature changes

### DIFF
--- a/qubesappmenusext/__init__.py
+++ b/qubesappmenusext/__init__.py
@@ -97,19 +97,18 @@ class AppmenusExtension(qubes.ext.Extension):
             asyncio.ensure_future(self.run_as_user(
                 ['qvm-appmenus', '--quiet', '--force', '--update', vm.name]))
 
+    @qubes.ext.handler('domain-feature-delete')
+    def on_feature_del_internal(self, vm, event, feature):
+        if feature == 'internal':
+            asyncio.ensure_future(self.run_as_user(
+                ['qvm-appmenus', '--quiet', '--create', vm.name]))
+
     @qubes.ext.handler('domain-feature-set')
     def on_feature_set_internal(self, vm, event, feature, value,
             oldvalue=None):
-        if feature != 'internal':
-            return
-        if oldvalue is None:
-            oldvalue = False
-        if value and not oldvalue:
+        if feature == 'internal':
             asyncio.ensure_future(self.run_as_user(
                 ['qvm-appmenus', '--quiet', '--remove', vm.name]))
-        elif not value and oldvalue:
-            asyncio.ensure_future(self.run_as_user(
-                ['qvm-appmenus', '--quiet', '--create', vm.name]))
 
     @qubes.ext.handler('template-postinstall')
     def on_template_postinstall(self, vm, event):

--- a/qubesappmenusext/__init__.py
+++ b/qubesappmenusext/__init__.py
@@ -84,6 +84,19 @@ class AppmenusExtension(qubes.ext.Extension):
         asyncio.ensure_future(self.run_as_user(
             ['qvm-appmenus', '--quiet', '--force', '--update', vm.name]))
 
+    @qubes.ext.handler('domain-feature-delete')
+    def on_feature_del_appmenus_dispvm(self, vm, event, feature):
+        if feature == 'appmenus-dispvm':
+            asyncio.ensure_future(self.run_as_user(
+                ['qvm-appmenus', '--quiet', '--force', '--update', vm.name]))
+
+    @qubes.ext.handler('domain-feature-set')
+    def on_feature_set_appmenus_dispvm(self, vm, event, feature,
+            value, oldvalue=None):
+        if feature == 'appmenus-dispvm':
+            asyncio.ensure_future(self.run_as_user(
+                ['qvm-appmenus', '--quiet', '--force', '--update', vm.name]))
+
     @qubes.ext.handler('domain-feature-set')
     def on_feature_set_internal(self, vm, event, feature, value,
             oldvalue=None):

--- a/qubesappmenusext/__init__.py
+++ b/qubesappmenusext/__init__.py
@@ -84,15 +84,17 @@ class AppmenusExtension(qubes.ext.Extension):
         asyncio.ensure_future(self.run_as_user(
             ['qvm-appmenus', '--quiet', '--force', '--update', vm.name]))
 
-    @qubes.ext.handler('domain-feature-set:internal')
-    def on_feature_set_internal(self, vm, event, feature, newvalue,
+    @qubes.ext.handler('domain-feature-set')
+    def on_feature_set_internal(self, vm, event, feature, value,
             oldvalue=None):
+        if feature != 'internal':
+            return
         if oldvalue is None:
             oldvalue = False
-        if newvalue and not oldvalue:
+        if value and not oldvalue:
             asyncio.ensure_future(self.run_as_user(
                 ['qvm-appmenus', '--quiet', '--remove', vm.name]))
-        elif not newvalue and oldvalue:
+        elif not value and oldvalue:
             asyncio.ensure_future(self.run_as_user(
                 ['qvm-appmenus', '--quiet', '--create', vm.name]))
 


### PR DESCRIPTION
I'm not sure that generic domain-feature-{set,delete} handlers checking the feature argument instead of specific domain-feature-{set,delete}:featurename events is the way to go - it seems a little inconsistent with other event handling. However, this is what the tests expect, and there's no authoritative documentation about which way it *should* be.

Discussion here: https://groups.google.com/d/topic/qubes-devel/tL756bswGpg/discussion