### PR TITLE
(DO NOT MERGE) Change menu layout for VM menu

### DIFF
--- a/qubesappmenus/__init__.py
+++ b/qubesappmenus/__init__.py
@@ -41,6 +41,8 @@ import qubesadmin.vm
 import qubesimgconverter
 
 basedir = os.path.join(xdg.BaseDirectory.xdg_data_home, 'qubes-appmenus')
+menus_dir = os.path.join(xdg.BaseDirectory.xdg_config_home,
+                         'menus', 'applications-merged')
 
 
 class DispvmNotSupportedError(qubesadmin.exc.QubesException):
@@ -328,6 +330,21 @@ class Appmenus(object):
                 desktop_menu_env = os.environ.copy()
                 desktop_menu_env['LC_COLLATE'] = 'C'
                 subprocess.check_call(desktop_menu_cmd, env=desktop_menu_env)
+
+                # this file makes sure the VM menu has Settings and/or Start on
+                # top, separated from inside-vm apps with a separator
+                self.write_desktop_file(
+                        vm,
+                        pkg_resources.resource_string(
+                            __name__,
+                            'qubes-vm-directory-settings.menu.template'
+                        ).decode(),
+                        os.path.join(
+                            menus_dir, '-'.join((
+                                'user',
+                                vm.name,
+                                'qubes-vm-directory-settings.menu'))))
+
             except subprocess.CalledProcessError:
                 vm.log.warning("Problem creating appmenus for %s", vm.name)
 

--- a/qubesappmenus/qubes-vm-directory-settings.menu.template
+++ b/qubesappmenus/qubes-vm-directory-settings.menu.template
@@ -10,10 +10,10 @@
         <Filename>%VMNAME%-qubes-start.desktop</Filename>
     </Include>
     <Layout>
+        <Merge type="all"/>
+        <Separator />
         <Filename>%VMNAME%-qubes-vm-settings.desktop</Filename>
         <Filename>%VMNAME%-qubes-start.desktop</Filename>
-        <Separator />
-        <Merge type="all"/>
     </Layout>
 </Menu>
 </Menu>

--- a/qubesappmenus/qubes-vm-directory-settings.menu.template
+++ b/qubesappmenus/qubes-vm-directory-settings.menu.template
@@ -1,0 +1,19 @@
+<!DOCTYPE Menu PUBLIC "-//freedesktop//DTD Menu 1.0//EN"
+    "http://www.freedesktop.org/standards/menu-spec/menu-1.0.dtd">
+<Menu>
+    <Name>Applications</Name>
+<Menu>
+    <Name>%VMNAME%-vm</Name>
+    <Directory>%VMNAME%-vm.directory</Directory>
+    <Include>
+        <Filename>%VMNAME%-qubes-vm-settings.desktop</Filename>
+        <Filename>%VMNAME%-qubes-start.desktop</Filename>
+    </Include>
+    <Layout>
+        <Filename>%VMNAME%-qubes-vm-settings.desktop</Filename>
+        <Filename>%VMNAME%-qubes-start.desktop</Filename>
+        <Separator />
+        <Merge type="all"/>
+    </Layout>
+</Menu>
+</Menu>

--- a/rpm_spec/desktop-linux-common.spec.in
+++ b/rpm_spec/desktop-linux-common.spec.in
@@ -69,6 +69,23 @@ xdg-icon-resource forceupdate
 
 #xdg-desktop-menu install /usr/share/qubes-appmenus/qubes-dispvm.directory /usr/share/qubes-appmenus/qubes-dispvm-*.desktop
 
+local_user=`getent group qubes | cut -d : -f 4 | cut -d , -f 1`
+if [ -n "$local_user" ]; then
+    call_as_user() {
+        su -c "$*" - $local_user
+    }
+else
+    # This will be the case during installation - user will be created in
+    # firstboot. There is also a code to fix file permissions, so not a big problem
+    call_as_user() {
+        $*
+    }
+fi
+
+for vm in $(qvm-ls --raw-list); do
+    call_as_user qvm-appmenus --update $vm
+done
+
 %preun
 if [ "$1" = 0 ] ; then
     # no more packages left
@@ -98,6 +115,7 @@ fi
 %{python3_sitelib}/qubesappmenus/qubes-vm.directory.template
 %{python3_sitelib}/qubesappmenus/qubes-dispvm.directory.template
 %{python3_sitelib}/qubesappmenus/qubes-start.desktop.template
+%{python3_sitelib}/qubesappmenus/qubes-vm-directory-settings.menu.template
 %{python3_sitelib}/qubesappmenus/tests.py
 %{python3_sitelib}/qubesappmenus/tests_integ.py
 %{python3_sitelib}/qubesappmenus/test-data


### PR DESCRIPTION
Move Settings and Start VM (if available) to the top of a VMs
menu, separated by a separator from inside-VM apps.

fixes QubesOS/qubes-issues#5447