### PR TITLE
debian: fix dependency names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ rpm/
 pkgs/
 __pycache__
 .coverage
+debian/changelog.*

--- a/Makefile
+++ b/Makefile
@@ -24,3 +24,5 @@ clean:
 	rm -rf qubesappmenus/__pycache__
 	rm -rf qubesappmenusext/__pycache__
 	rm -f .coverage
+	rm -rf debian/changelog.*
+	rm -rf pkgs

--- a/debian/control
+++ b/debian/control
@@ -17,8 +17,8 @@ X-Python3-Version: >= 3.4
 Package: qubes-desktop-linux-common
 Architecture: any
 Depends:
- python3-qubesimgconverter,
- python3-pyxdg,
+ qubes-utils,
+ python3-xdg,
  qubes-core-admin-client,
  ${python3:Depends},
  ${misc:Depends}

--- a/debian/control
+++ b/debian/control
@@ -17,7 +17,7 @@ X-Python3-Version: >= 3.4
 Package: qubes-desktop-linux-common
 Architecture: any
 Depends:
- qubes-utils,
+ qubes3-qubesimgconverter,
  python3-xdg,
  qubes-core-admin-client,
  ${python3:Depends},


### PR DESCRIPTION
QubesOS/qubes-issues#4186