### PR TITLE
appmenus: make it more robust about appmenus-dispvm feature access

### DIFF
--- a/qubesappmenus/__init__.py
+++ b/qubesappmenus/__init__.py
@@ -231,7 +231,10 @@ class Appmenus(object):
         if not os.path.exists(appmenus_dir):
             os.makedirs(appmenus_dir)
 
-        dispvm = vm.features.check_with_template('appmenus-dispvm', False)
+        try:
+            dispvm = vm.features.get('appmenus-dispvm', False)
+        except qubesadmin.exc.QubesDaemonNoResponseError:
+            dispvm = False
 
         anything_changed = False
         directory_changed = False


### PR DESCRIPTION
First, check the feature on the VM itself only - no sense for checking
it on the template. But then, handle also the case when Admin API call
was refused.

QubesOS/qubes-issues#833