### PR TITLE
Removed dependency on qubesmanager

### DIFF
--- a/qubesappmenus/qubes-vm-settings.desktop.template
+++ b/qubesappmenus/qubes-vm-settings.desktop.template
@@ -1,6 +1,7 @@
 [Desktop Entry]
 Version=1.0
 Type=Application
+TryExec=qubes-vm-settings
 Exec=qubes-vm-settings %VMNAME%
 Icon=qubes-appmenu-select
 Terminal=false

--- a/rpm_spec/desktop-linux-common.spec.in
+++ b/rpm_spec/desktop-linux-common.spec.in
@@ -23,7 +23,6 @@ Requires:	xorg-x11-utils
 Requires:	python%{python3_pkgversion}-qubesimgconverter
 Requires:	python%{python3_pkgversion}-qubesadmin
 Requires:	python%{python3_pkgversion}-pyxdg
-Requires:   qubes-manager
 
 %description
 Common code used for multiple desktop environments' Qubes integration


### PR DESCRIPTION
Appropriate menu entries will now show only when qubesmanager is installed.