### PR TITLE
Accept "+" as part of the Name, GenericName, and Comment fields on qvm-sync-appmenus

### DIFF
--- a/qubesappmenus/receive.py
+++ b/qubesappmenus/receive.py
@@ -64,7 +64,7 @@ appmenus_line_size = 1024
 appmenus_line_count = 100000
 
 # regexps for sanitization of retrieved values
-std_re = re.compile(r"^[/a-zA-Z0-9.,:&()_ -]*$")
+std_re = re.compile(r"^[/a-zA-Z0-9.,:&()_ +-]*$")
 fields_regexp = {
     "Name": std_re,
     "GenericName": std_re,


### PR DESCRIPTION
The plus sign is a valid character for these fields. Righ now,
qvm-sync-appmenus discards entries containing plus signs. This change
corrects that.