### PR TITLE
Ignore appmenus-dispvm unless template_for_dispvms=True

### DIFF
--- a/qubesappmenus/__init__.py
+++ b/qubesappmenus/__init__.py
@@ -232,8 +232,10 @@ class Appmenus(object):
             os.makedirs(appmenus_dir)
 
         try:
-            dispvm = vm.features.get('appmenus-dispvm', False)
-        except qubesadmin.exc.QubesDaemonNoResponseError:
+            dispvm = (vm.template_for_dispvms and
+                      vm.features.get('appmenus-dispvm', False))
+        except (qubesadmin.exc.QubesDaemonNoResponseError,
+                qubesadmin.exc.QubesNoSuchPropertyError):
             dispvm = False
 
         anything_changed = False

--- a/qubesappmenus/tests.py
+++ b/qubesappmenus/tests.py
@@ -69,6 +69,7 @@ class TestVM(object):
     def __init__(self, name, klass, **kwargs):
         self.running = False
         self.is_template = False
+        self.template_for_dispvms=False
         self.name = name
         self.klass = klass
         self.log = logging.getLogger('qubesappmenus.tests')

--- a/qubesappmenusext/__init__.py
+++ b/qubesappmenusext/__init__.py
@@ -85,6 +85,14 @@ class AppmenusExtension(qubes.ext.Extension):
         asyncio.ensure_future(self.run_as_user(
             ['qvm-appmenus', '--quiet', '--force', '--update', vm.name]))
 
+    @qubes.ext.handler('domain-feature-pre-set:appmenus-dispvm')
+    def on_feature_pre_set_appmenus_dispvm(self, vm, event, feature,
+            value, oldvalue=None):
+        if value and not vm.template_for_dispvms:
+            raise qubes.exc.QubesValueError(
+                '{} cannot have feature ‘appmenus-dispvm’ because is not a '
+                'DispVM template'.format(vm.name))
+
     @qubes.ext.handler('domain-feature-set:appmenus-dispvm')
     def on_feature_set_appmenus_dispvm(self, vm, event, feature,
             value, oldvalue=None):


### PR DESCRIPTION
Otherwise, we will try to start a DispVM based on a VM that is not a DispVM template, which cannot work.  Also block `appmenus-dispvm` from being set on a VM that is not a DispVM template.
    
Fixes QubesOS/qubes-issues#4636
Fixes QubesOS/qubes-issues#6683
