### PR TITLE
Add a --get-default-whitelist to qvm-appmenus

### DIFF
--- a/qubesappmenus/__init__.py
+++ b/qubesappmenus/__init__.py
@@ -641,6 +641,15 @@ class Appmenus(object):
         vm.features['default-menu-items'] = ' '.join(applications_list)
 
     @staticmethod
+    def get_default_whitelist(vm):
+        """
+        Get default applications list for VMs created on this template
+        :param vm: VM object
+        :return: list of applications in default whitelist
+        """
+        return vm.features.get('default-menu-items', '').split(' ')
+
+    @staticmethod
     def set_whitelist(vm, applications_list):
         """Update list of applications to be included in the menu
 
@@ -727,6 +736,11 @@ parser_stdin_mode.add_argument(
          'for VMs based on this template,'
          'use \'-\' to read from stdin')
 parser.add_argument(
+    '--get-default-whitelist', metavar='PATH',
+    help='Get default list of applications to include in menu '
+         'for VMs based on this template'
+)
+parser.add_argument(
     '--source', action='store', default=None,
     help='Source VM to copy data from (for --init option)')
 parser.add_argument(
@@ -811,6 +825,9 @@ def main(args=None, app=None):
             if args.set_default_whitelist:
                 whitelist = retrieve_list(args.set_default_whitelist)
                 appmenus.set_default_whitelist(vm, whitelist)
+            if args.get_default_whitelist:
+                default_whitelist = appmenus.get_default_whitelist(vm)
+                print('\n'.join(default_whitelist))
             if args.set_whitelist:
                 whitelist = retrieve_list(args.set_whitelist)
                 appmenus.set_whitelist(vm, whitelist)

--- a/qubesappmenus/tests.py
+++ b/qubesappmenus/tests.py
@@ -658,6 +658,20 @@ class TC_00_Appmenus(unittest.TestCase):
             ('info', ('Creating evince',), {}),
         ])
 
+    @unittest.mock.patch('subprocess.check_call')
+    def test_131_set_get_default_whitelist(self, mock_subprocess):
+        tpl = TestVM('test-inst-tpl',
+            klass='TemplateVM',
+            virt_mode='pvh',
+            updateable=True,
+            provides_network=False,
+            label=self.app.labels[1])
+        self.ext.appmenus_init(tpl)
+
+        whitelist = ['evince.desktop', 'xterm.desktop']
+
+        self.ext.set_default_whitelist(tpl, whitelist)
+        self.assertEqual(whitelist, self.ext.get_default_whitelist(tpl))
 
 
 def list_tests():


### PR DESCRIPTION
Simple new function and associated tests, to be
complementary to --set-default-whitelist.