### PR TITLE
ci: use a wrapper to properly mark coverage data

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -18,6 +18,5 @@ checks:tests:
     - python3 -m pylint qubesappmenus
     - python3 -m coverage run -m unittest -v qubesappmenus.tests
   after_script:
-    - "PATH=$PATH:$HOME/.local/bin"
-    - codecov -F unittests
+    - ci/codecov-wrapper -F unittests
 

--- a/ci/codecov-wrapper
+++ b/ci/codecov-wrapper
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+PATH="$PATH:$HOME/.local/bin"
+
+set -x
+
+if [[ "$CI_COMMIT_BRANCH" =~ ^pr- ]]; then
+    PR=${CI_COMMIT_BRANCH#pr-}
+    parents=$(git show -s --format='%P %ae')
+    if [ $(wc -w <<<"$parents") -eq 3 ] && [ "${parents##* }" = "fepitre-bot@qubes-os.org" ]; then
+        commit_sha=$(cut -f 2 -d ' ' <<<"${parents}")
+    else
+        commit_sha=$(git show -s --format='%H')
+    fi
+    exec codecov --pr "$PR" --commit "$commit_sha" "$@"
+fi
+exec codecov "$@"


### PR DESCRIPTION
Since our CI doesn't re-use github's merge commits anymore, codecov
needs to be helped to get the right commit ID.