### PR TITLE
Fix `_is_old_path` for dispvm directory names

### DIFF
--- a/qubesappmenus/__init__.py
+++ b/qubesappmenus/__init__.py
@@ -457,7 +457,8 @@ class Appmenus(object):
         """Return if a path to a desktop name is for the old menu version.
         """
         return not (name.startswith('org.qubes-os.') or
-                    name.startswith('qubes-vm-directory-'))
+                    name.startswith('qubes-vm-directory-') or
+                    name.startswith('qubes-dispvm-directory-'))
 
     def _old_directory_path(self, vm):
         """Return the old path of the directory file for this VM


### PR DESCRIPTION
Fixes [qubes-issues#7705](https://github.com/QubesOS/qubes-issues/issues/7705)

Currently appmenus removal on dispvm templates errors out:

```
xdg-desktop-menu: desktop-file argument missing
Try 'xdg-desktop-menu --help' for more information.
Problem removing appmenus for test-dvm
```

This appears to be coming from an ill-formed call to `xdg-desktop-menu`, which happens because `_is_old_path` is not correctly checked for dispvm directory names.