### PR TITLE
Remove old global settings from menu

### DIFF
--- a/qubes-menus/menus/qubes-applications.menu
+++ b/qubes-menus/menus/qubes-applications.menu
@@ -50,7 +50,6 @@
             <Filename>qubes-new-qube.desktop</Filename>
             <Filename>qubes-backup.desktop</Filename>
             <Filename>qubes-backup-restore.desktop</Filename>
-            <Filename>qubes-global-settings.desktop</Filename>
             <Filename>qubes-global-config.desktop</Filename>
             <Filename>qubes-qube-manager.desktop</Filename>
             <Filename>qubes-template-manager.desktop</Filename>


### PR DESCRIPTION
obsoleted by new global config in https://github.com/QubesOS/qubes-desktop-linux-manager

fixes QubesOS/qubes-issues#8201
fixes QubesOS/qubes-issues#8200