### PR TITLE
Catching exceptions with `qvm-appmenus` and `qvm-sync-appmenus`

### DIFF
--- a/qubesappmenus/__init__.py
+++ b/qubesappmenus/__init__.py
@@ -828,7 +828,10 @@ def main(args=None, app=None):
         # for other actions - get VM object
         if not args.remove:
             if not isinstance(vm, qubesadmin.vm.QubesVM):
-                vm = args.app.domains[vm]
+                try:
+                    vm = args.app.domains[vm]
+                except KeyError:
+                    parser.error('VMNAME is not an existing qube')
             if args.init:
                 appmenus.appmenus_init(vm, src=args.source)
             if args.get_whitelist:

--- a/qubesappmenus/__init__.py
+++ b/qubesappmenus/__init__.py
@@ -831,7 +831,7 @@ def main(args=None, app=None):
                 try:
                     vm = args.app.domains[vm]
                 except KeyError:
-                    parser.error('VMNAME is not an existing qube')
+                    parser.error("'{0}' is not an existing qube".format(vm))
             if args.init:
                 appmenus.appmenus_init(vm, src=args.source)
             if args.get_whitelist:

--- a/qubesappmenus/receive.py
+++ b/qubesappmenus/receive.py
@@ -404,7 +404,11 @@ def main(args=None):
         use_stdin = True
     appmenusext = qubesappmenus.Appmenus()
     if not args.regenerate_only:
-        new_appmenus = retrieve_appmenus_templates(vm, use_stdin=use_stdin)
+        try:
+            new_appmenus = retrieve_appmenus_templates(vm, use_stdin=use_stdin)
+        except qubesadmin.exc.QubesVMNotRunningError as e:
+            parser.error(str(e))
+
         if not new_appmenus and vm.klass != "AppVM":
             vm.log.info("No appmenus received, terminating")
         else:


### PR DESCRIPTION
`qvm-sync-appmenus` called with a non-running qube now fails with a user-friendly error message. See QubesOS/qubes-issues#9836

Another minor fix is provided when calling `qvm-appmenus ... VMNAME` where `VMNAME` doesn't exist.