### PR TITLE
Disable wayland session by default

### DIFF
--- a/rpm_spec/desktop-linux-common.spec.in
+++ b/rpm_spec/desktop-linux-common.spec.in
@@ -51,6 +51,13 @@ This package contains the XML files that describe the menu layout for
 GNOME and KDE, and the .desktop files that define the names and icons
 of "subdirectories" in the menus.
 
+%package wayland
+Summary: Configuration to enable Wayland session
+Group: User Interface/Desktops
+
+%description wayland
+This package enables experimental wayland session support.
+
 %prep
 %setup -q
 
@@ -61,6 +68,7 @@ make -C doc manpages PYTHON=%{__python3}
 %install
 make DESTDIR=$RPM_BUILD_ROOT MANDIR=%{_mandir} PYTHON=%{__python3} install
 make -C doc DESTDIR=$RPM_BUILD_ROOT MANDIR=%{_mandir} PYTHON=%{__python3} install
+make -C wayland-config DESTDIR=$RPM_BUILD_ROOT install
 
 %post
 for i in /usr/share/qubes/icons/*.png ; do
@@ -116,6 +124,9 @@ fi
 /usr/bin/qvm-sync-appmenus
 /usr/bin/qvm-appmenus
 
+/usr/lib/sddm/sddm.conf.d/10-qubes-wayland-off.conf
+/usr/share/lightdm/lightdm.conf.d/10-qubes-wayland-off.conf
+
 %files -n qubes-menus
 %defattr(-,root,root)
 %doc qubes-menus/README
@@ -126,6 +137,10 @@ fi
 %dir %{_sysconfdir}/xdg/menus/settings-merged
 %config %{_sysconfdir}/xdg/menus/*.menu
 %{_datadir}/desktop-directories/*.directory
+
+%files wayland
+/usr/lib/sddm/sddm.conf.d/15-qubes-wayland-on.conf
+/usr/share/lightdm/lightdm.conf.d/15-qubes-wayland-on.conf
 
 %changelog
 @CHANGELOG@

--- a/wayland-config/Makefile
+++ b/wayland-config/Makefile
@@ -1,0 +1,12 @@
+all:
+	@true
+
+install:
+	install -D -m0644 lightdm-10-qubes-wayland-off.conf \
+		$(DESTDIR)/usr/share/lightdm/lightdm.conf.d/10-qubes-wayland-off.conf
+	install -D -m0644 lightdm-15-qubes-wayland-on.conf \
+		$(DESTDIR)/usr/share/lightdm/lightdm.conf.d/15-qubes-wayland-on.conf
+	install -D -m0644 sddm-10-qubes-wayland-off.conf \
+		$(DESTDIR)/usr/lib/sddm/sddm.conf.d/10-qubes-wayland-off.conf
+	install -D -m0644 sddm-15-qubes-wayland-on.conf \
+		$(DESTDIR)/usr/lib/sddm/sddm.conf.d/15-qubes-wayland-on.conf

--- a/wayland-config/lightdm-10-qubes-wayland-off.conf
+++ b/wayland-config/lightdm-10-qubes-wayland-off.conf
@@ -1,0 +1,3 @@
+[LightDM]
+# exclude wayland sessions by default as wayland is still experimental in qubes
+sessions-directory=/usr/share/lightdm/sessions:/usr/share/xsessions

--- a/wayland-config/lightdm-15-qubes-wayland-on.conf
+++ b/wayland-config/lightdm-15-qubes-wayland-on.conf
@@ -1,0 +1,3 @@
+[LightDM]
+# re-enable wayland sessions at explicit request
+sessions-directory=/usr/share/lightdm/sessions:/usr/share/xsessions:/usr/share/wayland-sessions

--- a/wayland-config/sddm-10-qubes-wayland-off.conf
+++ b/wayland-config/sddm-10-qubes-wayland-off.conf
@@ -1,0 +1,2 @@
+[Wayland]
+SessionDir=

--- a/wayland-config/sddm-15-qubes-wayland-on.conf
+++ b/wayland-config/sddm-15-qubes-wayland-on.conf
@@ -1,0 +1,2 @@
+[Wayland]
+SessionDir=/usr/local/share/wayland-sessions,/usr/share/wayland-sessions


### PR DESCRIPTION
The wayland session support is experimental, don't enable it by default,
as users may not realize its support status.

And add desktop-linux-common-wayland package to re-enable it.

QubesOS/qubes-issues#8515