### PR TITLE
added qvm-sensible-browser

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ all:
 install:
 	## Tools
 	install -D -m755 tools/qvm-xkill $(DESTDIR)/usr/bin/qvm-xkill
+	install -D -m755 tools/qvm-sensible-browser $(DESTDIR)/usr/bin/qvm-sensible-browser
 
 	### Icons
 	mkdir -p $(DESTDIR)/usr/share/qubes/icons

--- a/debian/qubes-desktop-linux-common.install
+++ b/debian/qubes-desktop-linux-common.install
@@ -1,6 +1,7 @@
 usr/bin/qvm-appmenus
 usr/bin/qvm-xkill
 usr/bin/qvm-sync-appmenus
+usr/bin/qvm-sensible-browser
 usr/share/qubes/icons/*.png
 usr/share/icons/hicolor/scalable/apps/qubes-vm-settings.svg
 usr/lib/python3/dist-packages/qubesappmenus/*

--- a/doc/tools/qvm-sensible-browser.rst
+++ b/doc/tools/qvm-sensible-browser.rst
@@ -1,0 +1,23 @@
+=========
+qvm-xget-focus
+=========
+
+NAME
+====
+qvm-sensible-browser
+
+
+SYNOPSIS
+========
+| qvm-sensible-browser
+
+DESCRIPTION
+===========
+qvm-sensible-browser opens a browser in currently focused vm, opens whatever browser is default in that qube.
+
+qvm-sensible-browser is useful whenever you want to open a browser, was built to be more convinient than to open qubes-app-menu.
+
+
+AUTHORS
+=======
+| unamed1234 <unamed01 at proton.me>

--- a/rpm_spec/desktop-linux-common.spec.in
+++ b/rpm_spec/desktop-linux-common.spec.in
@@ -92,6 +92,7 @@ fi
 %files
 %defattr(-,root,root,-)
 %{_bindir}/qvm-xkill
+%{_bindir}/qvm-sensible-browser
 %{_mandir}/man1/qvm-*.1*
 %dir %{python3_sitelib}/qubesdesktop-*.egg-info
 %{python3_sitelib}/qubesdesktop-*.egg-info/*

--- a/tools/qvm-sensible-browser
+++ b/tools/qvm-sensible-browser
@@ -1,0 +1,125 @@
+#!/usr/bin/bash --posix
+
+#adapted from https://github.com/QubesOS/qubes-desktop-linux-i3-settings-qubes/blob/main/qubes-i3-sensible-terminal
+
+# Set POSIX-compliant mode to make bash and certain utils more predictable.
+# Bash-specific features are still used, that's intentional
+POSIXLY_CORRECT=1
+set -o posix
+readonly POSIXLY_CORRECT
+export POSIXLY_CORRECT
+
+# Set IFS explicitly. POSIX does not enforce whether IFS should be inherited
+# from the environment, so it's safer to set it explicitly
+IFS=$' \t\n'
+export IFS
+
+# Exit on errors and unset variables
+set -eEu
+
+print_usage() {
+  cat <<USAGE >&2
+Usage:  $(basename "$0") [--disposable] [--user USER]
+
+Options:
+  -h, --help        print this usage information
+  -d, --disposable  launch browser in current vm as disposable instead (will fallback to default_dispvm if currently focused vm isn't template_for_dispvms)
+  -u, --user        run browser as specified user 
+USAGE
+  return 0
+}
+domU_launch_browser() {
+  if [[ "$arg_user" != "DEFAULT" ]]; then
+    echo https:// | qrexec-client -d "$vm" "$arg_user:QUBESRPC qubes.OpenURL dom0"
+  else
+    echo https:// | qrexec-client -d "$vm" 'DEFAULT:QUBESRPC qubes.OpenURL dom0'
+  fi
+}
+
+disp_launch_browser() {
+  #if current vm cant be dispvm fallback to default dispvm
+  if [[ "$vm" != "dom0" && "$(qvm-prefs "$vm" template_for_dispvms 2>/dev/null)" != "True" ]]; then
+    dispvm="$(qubes-prefs default_dispvm)"
+  else
+    dispvm="$vm"
+  fi
+  if [[ "$arg_user" != "DEFAULT" ]]; then
+    echo https:// | qvm-run -u "$arg_user" -p --service --dispvm "$dispvm" qubes.OpenURL >/dev/null 2>&1 &
+  else
+    echo https:// | qvm-run -p --service --dispvm "$dispvm" qubes.OpenURL >/dev/null 2>&1 &
+  fi
+}
+
+main() {
+  vm="$(/usr/bin/qvm-xget-focus)"
+  declare -g vm
+  if test "$vm" = "dom0" && test "$arg_disposable" != "true"; then
+    echo dom0 doesn\'t have a browser
+    exit 1
+  fi
+  if test "$arg_disposable" = "true"; then
+    disp_launch_browser
+    exit $?
+  fi
+  domU_launch_browser
+}
+
+# Adapted from https://stackoverflow.com/a/29754866
+parse_options() {
+  declare -g arg_user="DEFAULT"
+  declare -g arg_disposable=""
+
+  if [ $# -lt 1 ]; then
+    return
+  fi
+  # Check whether getopt version is "enhanced"
+  # shellcheck disable=SC2251
+  ! getopt --test >/dev/null
+  if [[ ${PIPESTATUS[0]} -ne 4 ]]; then
+    printf '%s\n' 'This script requires getopt enhanced to work properly' >&2
+    exit 2
+  fi
+
+  # Set available options
+  declare -r LONGOPTS=help,disposable,user:
+  declare -r OPTIONS=hdu:
+
+  # Get arguments from "$@" using getopt
+  IFS=" " read -r -a PARSED <<<"$(getopt --options=$OPTIONS --longoptions=$LONGOPTS --name "$0" -- "$@")"
+  eval set -- "${PARSED[*]}"
+
+  # Write to argument variables
+  while true; do
+    case "$1" in
+    -h | --help)
+      print_usage
+      exit 0
+      ;;
+    -u | --user)
+      arg_user="$2"
+      shift 2
+      ;;
+    -d | --disposable)
+      arg_disposable="true"
+      shift
+      ;;
+    --)
+      shift
+      break
+      ;;
+    *)
+      printf '%s\n' "$(basename "$0"): Invalid argument" >&2
+      print_usage
+      exit 2
+      ;;
+    esac
+  done
+
+  declare -gr arg_user
+  declare -gr arg_disposable
+
+  return
+}
+
+parse_options "$@"
+main

--- a/tools/qvm-sensible-file-manager
+++ b/tools/qvm-sensible-file-manager
@@ -23,45 +23,46 @@ Usage:  $(basename "$0") [--disposable] [--user USER]
 
 Options:
   -h, --help        print this usage information
-  -d, --disposable  launch browser in current vm as disposable instead (will fallback to default_dispvm if currently focused vm isn't template_for_dispvms)
-  -u, --user        run browser as specified user 
+  -d, --disposable  launch file manager in current vm as disposable instead (will fallback to default_dispvm if currently focused vm isn't template_for_dispvms)
+  -u, --user        run file manager as specified user 
 USAGE
   return 0
 }
-domU_launch_browser() {
+domU_launch_terminal() {
   if [[ "$arg_user" != "DEFAULT" ]]; then
-    echo https:// | qrexec-client -d "$vm" "$arg_user:QUBESRPC qubes.OpenURL dom0"
+    qrexec-client -d "$vm" "$arg_user:qubes-open ."
   else
-    echo https:// | qrexec-client -d "$vm" 'DEFAULT:QUBESRPC qubes.OpenURL dom0'
+    qrexec-client -d "$vm" 'DEFAULT:qubes-open .'
   fi
 }
 
-disp_launch_browser() {
+disp_launch_terminal() {
   #if current vm cant be dispvm fallback to default dispvm
-  if [[ "$vm" != "dom0" && "$(qvm-prefs "$vm" template_for_dispvms 2>/dev/null)" != "True" ]]; then
+  if [[ "$(qvm-prefs "$vm" template_for_dispvms 2>/dev/null)" != "True" ]]; then
     dispvm="$(qubes-prefs default_dispvm)"
   else
     dispvm="$vm"
   fi
   if [[ "$arg_user" != "DEFAULT" ]]; then
-    echo https:// | qvm-run -u "$arg_user" -p --service --dispvm "$dispvm" qubes.OpenURL >/dev/null 2>&1 &
+    qvm-run -u "$arg_user" --dispvm "$dispvm" qubes-open . >/dev/null 2>&1 &
   else
-    echo https:// | qvm-run -p --service --dispvm "$dispvm" qubes.OpenURL >/dev/null 2>&1 &
+    qvm-run --dispvm "$dispvm" qubes-open . >/dev/null 2>&1 &
   fi
 }
 
 main() {
   vm="$(/usr/bin/qvm-xget-focus)"
   declare -g vm
-  if test -z "$vm" && [ "$arg_disposable" != "true" ]; then
-    echo dom0 doesn\'t have a browser
+  if test -z "$vm" && test "$arg_disposable" != "true"; then
+    #vm is dom0
+    xdg-open .
     exit 1
   fi
   if test "$arg_disposable" = "true"; then
-    disp_launch_browser
+    disp_launch_terminal
     exit $?
   fi
-  domU_launch_browser
+  domU_launch_terminal
 }
 
 # Adapted from https://stackoverflow.com/a/29754866

--- a/tools/qvm-sensible-terminal
+++ b/tools/qvm-sensible-terminal
@@ -1,0 +1,148 @@
+#!/usr/bin/bash --posix
+
+#somewhat adapted from https://github.com/QubesOS/qubes-desktop-linux-i3-settings-qubes/blob/main/qubes-i3-sensible-terminal
+
+# Set POSIX-compliant mode to make bash and certain utils more predictable.
+# Bash-specific features are still used, that's intentional
+POSIXLY_CORRECT=1
+set -o posix
+readonly POSIXLY_CORRECT
+export POSIXLY_CORRECT
+
+# Set IFS explicitly. POSIX does not enforce whether IFS should be inherited
+# from the environment, so it's safer to set it explicitly
+IFS=$' \t\n'
+export IFS
+
+# Exit on errors and unset variables
+set -eEu
+
+declare -r DOMU_TERMINAL="qubes-run-terminal"
+declare -r DOMU_CONSOLE="qvm-console-dispvm"
+
+print_usage() {
+  cat <<USAGE >&2
+Usage:  $(basename "$0") [--console] [--user USER]
+
+Options:
+  -h, --help        print this usage information
+  -c, --console     launch disposable console instead of terminal
+  -u, --user        run terminal as specified user
+USAGE
+  return 0
+}
+
+#from https://github.com/i3/i3/blob/next/i3-sensible-terminal
+dom0_terminal() {
+  if [[ "$arg_user" = "DEFAULT" ]];then
+  for terminal in x-terminal-emulator xfce4-terminal xterm st mate-terminal gnome-terminal terminator urxvt rxvt termit Eterm aterm uxterm roxterm termite lxterminal terminology qterminal lilyterm tilix terminix konsole kitty guake tilda alacritty hyper wezterm rio ghostty; do
+    command -v "$terminal" &>/dev/null && exec "$terminal"
+  else 
+  for terminal in x-terminal-emulator xfce4-terminal xterm st mate-terminal gnome-terminal terminator urxvt rxvt termit Eterm aterm uxterm roxterm termite lxterminal terminology qterminal lilyterm tilix terminix konsole kitty guake tilda alacritty hyper wezterm rio ghostty; do
+    command -v "$terminal" &>/dev/null && exec sudo -u "$arg_user" "$terminal"
+  done
+}
+
+main() {
+  vm="$(/usr/bin/qvm-xget-focus)"
+
+  if test -z "$vm"; then
+      dom0_terminal
+      exit $?
+  fi
+
+  # Launch console for VM (hvc)
+  if test "$arg_console" = "true"; then
+    exec -- "$DOMU_CONSOLE" -- "$vm"
+  fi
+
+  if command -v qrexec-client >/dev/null; then
+    exec -- qrexec-client -e -d "$vm" -- \
+      "$arg_user:QUBESRPC qubes.StartApp+$DOMU_TERMINAL $vm"
+  fi
+
+  # Else, if qrexec-client can't be used (e.g. in a GUIVM), use qvm-run instead
+  case "$arg_user" in
+  DEFAULT)
+    exec qvm-run --no-gui --service -- "$vm" qubes.StartApp+"$DOMU_TERMINAL"
+    ;;
+  *)
+    exec qvm-run --no-gui --service -u "$arg_user" -- "$vm" qubes.StartApp+"$DOMU_TERMINAL"
+    ;;
+  esac
+}
+
+# Adapted from https://stackoverflow.com/a/29754866
+parse_options() {
+  declare -g arg_user="DEFAULT"
+  declare -g arg_console=""
+
+  if [ $# -lt 1 ]; then
+    return
+  fi
+  # Check whether getopt version is "enhanced"
+  # shellcheck disable=SC2251
+  ! getopt --test >/dev/null
+  if [[ ${PIPESTATUS[0]} -ne 4 ]]; then
+    printf '%s\n' 'This script requires getopt enhanced to work properly' >&2
+    exit 2
+  fi
+
+  # Set available options
+  declare -r LONGOPTS=help,console,user:
+  declare -r OPTIONS=hcu:
+
+  # Get arguments from "$@" using getopt
+  IFS=" " read -r -a PARSED <<<"$(getopt --options=$OPTIONS --longoptions=$LONGOPTS --name "$0" -- "$@")"
+  eval set -- "${PARSED[*]}"
+
+  # Write to argument variables
+  while true; do
+    case "$1" in
+    -h | --help)
+      print_usage
+      exit 0
+      ;;
+    -u | --user)
+      arg_user="$2"
+      shift 2
+      ;;
+    -c | --console)
+      arg_console="true"
+      shift
+      ;;
+    --)
+      shift
+      break
+      ;;
+    *)
+      printf '%s\n' "$(basename "$0"): Invalid argument" >&2
+      print_usage
+      exit 2
+      ;;
+    esac
+  done
+
+  # Handle positional arguments ($1, $2, …)
+  if [ $# -gt 0 ]; then
+    case "${1-}" in
+    console)
+      arg_console="true"
+      printf '%s\n' "$(basename "$0"): Positional arguments are deprecated and will be removed in the future. Use --console instead" >&2
+      ;;
+    *)
+      printf '%s\n' "$(basename "$0"): Invalid argument" >&2
+      print_usage
+      exit 2
+      ;;
+    esac
+  fi
+
+  declare -gr arg_user
+  declare -gr arg_console
+
+  return
+}
+
+parse_options "$@"
+main


### PR DESCRIPTION
https://github.com/QubesOS/qubes-desktop-linux-i3-settings-qubes/pull/25 ( I made it not bad since then but premise is the same) 
I believe this is a good QOL change to qubes. Normally you need a mess of several keybinds or go trough qubes-app-menu every single time just to open a simple browser this script just automates finding current focused qube (using https://github.com/QubesOS/qubes-desktop-linux-common/pull/75 ) then opens the default browser in that qube, this is a major UX improvement from before from my experience. also supports opening browser in dispvm with -d|--disposable option (will try to make a disposable of current focused vm then fallback to default_dispvm) and setting user trough -u|--user.
let me know what you think, thanks for your time!